### PR TITLE
fix: move pretty_env_logger -> env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,17 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,9 +266,9 @@ dependencies = [
  "clap_complete",
  "control-file",
  "csv",
+ "env_logger",
  "lazy_static",
  "log",
- "pretty_env_logger",
  "regex",
  "reqwest",
  "serde",
@@ -298,12 +287,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -502,12 +491,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -847,16 +833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,12 +864,6 @@ checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ clap = { version = "4.0.29", features = ["derive"] }
 clap_complete = "4.0.5"
 csv = "1.1.6"
 log = "0.4"
-pretty_env_logger = "0.4"
 regex = "1.7.0"
 reqwest = { version = "0.11.13", features = ["blocking", "json"] }
 serde = { version = "1.0.149", features = ["serde_derive"] }
@@ -28,6 +27,7 @@ thiserror = "1.0.37"
 control-file = { path = "./lib/control-file/", version = "0.1.0" }
 lazy_static = "1.4.0"
 chrono = "0.4.23"
+env_logger = "0.10.0"
 
 [profile.release]
 lto = "fat"

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,6 @@ use std::{
     path::Path,
 };
 
-extern crate pretty_env_logger;
 #[macro_use]
 extern crate log;
 
@@ -39,7 +38,7 @@ use self::{cli::CliArgs, deb::read_popcon};
 use clap::Parser;
 
 fn main() -> Result<(), DebNixError> {
-    pretty_env_logger::init();
+    env_logger::init();
     let opts = CliArgs::parse();
     let state = State::from_opts(opts.clone())?;
 


### PR DESCRIPTION
`env_logger` seems to be more actively maintained.
